### PR TITLE
Separate status menu buttons

### DIFF
--- a/scripts/statusMenu.js
+++ b/scripts/statusMenu.js
@@ -111,9 +111,14 @@ function addStatusMenu(t, mobile){
     table.row();
 
     /* Buttons */
+    table.table(null, b => {
+        b.defaults().size(210, 64);
+
+        b.button("$tu.apply-effect", Icon.add, apply).padRight(6);
+        b.button("$tu.apply-perma", Icon.add, applyPerma);
+    }).growX();
+
     dialog.addCloseButton();
-    dialog.buttons.button("$tu.apply-effect", Icon.add, apply);
-    dialog.buttons.button("$tu.apply-perma", Icon.add, applyPerma);
     dialog.buttons.button("$tu.clear-effects", Icon.cancel, clearStatuses);
 
     /* Set clicky */


### PR DESCRIPTION
This should fix the issue with mobile platforms cropping the buttons. *(Although you can fix that by just manually configuring the size.)* The two apply buttons are positioned below the status selection. Below are the pictures before and after the changes respectively.

![](https://media.discordapp.net/attachments/851064887450009633/856369354525114378/Screenshot_2021-06-21-09-47-01-542_io.anuke.mindustry.be.jpg?width=190&height=411)
![](https://media.discordapp.net/attachments/851064887450009633/856369301329412106/Screenshot_2021-06-21-10-01-21-266_io.anuke.mindustry.be.jpg?width=190&height=411)